### PR TITLE
Fixes code example for client.index

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const client = new elasticsearch.Client({
 
 // use in the normal way
 async function example() {
-  await client.index({ index: 'test', doc: { test: 'hello' } });
+  await client.index({ index: 'test', body: { test: 'hello' } });
   await client.indices.refresh();
   let result = await client.search({ index: 'test' });
 }


### PR DESCRIPTION
Correct key is `body`instead of `doc` 

See https://github.com/elastic/elasticsearch-js