### PR TITLE
Update to elasticsearch v7.16 to fix deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,14 @@
   "requires": true,
   "dependencies": {
     "@elastic/elasticsearch": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.12.0.tgz",
-      "integrity": "sha512-GquUEytCijFRPEk3DKkkDdyhspB3qbucVQOwih9uNyz3iz804I+nGBUsFo2LwVvLQmQfEM0IY2+yoYfEz5wMug==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.16.0.tgz",
+      "integrity": "sha512-lMY2MFZZFG3om7QNHninxZZOXYx3NdIUwEISZxqaI9dXPoL3DNhU31keqjvx1gN6T74lGXAzrRNP4ag8CJ/VXw==",
       "requires": {
         "debug": "^4.3.1",
         "hpagent": "^0.1.1",
         "ms": "^2.1.3",
-        "pump": "^3.0.0",
-        "secure-json-parse": "^2.3.1"
+        "secure-json-parse": "^2.4.0"
       }
     },
     "@ungap/promise-all-settled": {
@@ -427,9 +426,9 @@
       "dev": true
     },
     "hpagent": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.1.tgz",
-      "integrity": "sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
+      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ=="
     },
     "ieee754": {
       "version": "1.1.13",
@@ -701,9 +700,9 @@
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "secure-json-parse": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.3.2.tgz",
-      "integrity": "sha512-4oUSFU0w2d8/XQb7NO9dbMYyp/hxIwZPcZcGAlAAEziMRHs+NbUcx2Z5dda/z8o+avyQ8gpuYnTMlGh8SVwg9g=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
+      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
     },
     "serialize-javascript": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/gosquared/aws-elasticsearch-js#readme",
   "dependencies": {
-    "@elastic/elasticsearch": "^7.12.0",
+    "@elastic/elasticsearch": "^7.16.0",
     "aws-sdk": "^2.873.0",
     "debug": "^4.3.1",
     "pump": "^3.0.0"


### PR DESCRIPTION
We see a deprecated folder mapping warning when using node v16+

```
(node:97520) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at /Users/marcbachmann/Development/livingdocsIO/livingdocs-server/master/node_modules/@elastic/elasticsearch7/package.json.
Update this package.json to use a subpath pattern like "./*".
...
```

Raised here: https://github.com/elastic/elasticsearch-js/issues/1465
Fixed here: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/changelog-client.html#_fixed_export_field_deprecation_log_1593